### PR TITLE
fix: add helper functions to truncate resource names to 63 chars

### DIFF
--- a/workspace-templates/diloco-training/templates/_helpers.tpl
+++ b/workspace-templates/diloco-training/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Create a safe resource name that respects Kubernetes naming limits.
+This helper ensures the final name doesn't exceed 63 characters.
+Usage: {{ include "diloco-training.safeName" (dict "base" .Values.deploymentName "suffix" "config") }}
+*/}}
+{{- define "diloco-training.safeName" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $fullSuffix := printf "-%s" $suffix -}}
+{{- $maxBaseLength := sub 63 (len $fullSuffix) -}}
+{{- if gt (len $base) $maxBaseLength -}}
+{{- $truncatedBase := $base | trunc (int $maxBaseLength) -}}
+{{- printf "%s%s" $truncatedBase $fullSuffix -}}
+{{- else -}}
+{{- printf "%s%s" $base $fullSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a safe job name specifically for diloco-training resources.
+*/}}
+{{- define "diloco-training.jobName" -}}
+{{- .Values.deploymentName | trunc 63 -}}
+{{- end -}}
+
+{{/*
+Create a safe configmap name specifically for diloco-training configmap.
+*/}}
+{{- define "diloco-training.configmapName" -}}
+{{- include "diloco-training.safeName" (dict "base" .Values.deploymentName "suffix" "config") -}}
+{{- end -}}

--- a/workspace-templates/diloco-training/templates/configmap.yaml
+++ b/workspace-templates/diloco-training/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.deploymentName }}-config
+  name: {{ include "diloco-training.configmapName" . }}
   namespace: {{ .Values.deploymentNamespace }}
 data:
 {{- if .Values.diloco.model }}

--- a/workspace-templates/diloco-training/templates/ddp-job.yaml
+++ b/workspace-templates/diloco-training/templates/ddp-job.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch.volcano.sh/v1alpha1
 kind: Job
 metadata:
-  name: {{ .Values.deploymentName }}
+  name: {{ include "diloco-training.jobName" . }}
   namespace: {{ .Values.deploymentNamespace }}
   labels:
-    job-name: {{ .Values.deploymentName }}
+    job-name: {{ include "diloco-training.jobName" . }}
 spec:
   maxRetry: 3
   minAvailable: 2
@@ -27,9 +27,9 @@ spec:
       template:
         metadata:
           annotations:
-            scheduling.k8s.io/group-name: {{ .Values.deploymentName }}
+            scheduling.k8s.io/group-name: {{ include "diloco-training.jobName" . }}
           labels:
-            job-name: {{ .Values.deploymentName }}
+            job-name: {{ include "diloco-training.jobName" . }}
             role: master
         spec:
           containers:
@@ -38,7 +38,7 @@ spec:
                 - /app/diloco_training/training/start_training.py
               envFrom:
                 - configMapRef:
-                    name: {{ .Values.deploymentName }}-config
+                    name: {{ include "diloco-training.configmapName" . }}
               image: {{ .Values.deploymentImage }}
               imagePullPolicy: IfNotPresent
               name: master
@@ -61,9 +61,9 @@ spec:
       template:
         metadata:
           annotations:
-            scheduling.k8s.io/group-name: {{ .Values.deploymentName }}
+            scheduling.k8s.io/group-name: {{ include "diloco-training.jobName" . }}
           labels:
-            job-name: {{ .Values.deploymentName }}
+            job-name: {{ include "diloco-training.jobName" . }}
             role: worker
         spec:
           containers:
@@ -72,7 +72,7 @@ spec:
                 - /app/diloco_training/training/start_training.py
               envFrom:
                 - configMapRef:
-                    name: {{ .Values.deploymentName }}-config
+                    name: {{ include "diloco-training.configmapName" . }}
               image: {{ .Values.deploymentImage }}
               imagePullPolicy: IfNotPresent
               name: worker

--- a/workspace-templates/jupyter-notebook/templates/_helpers.tpl
+++ b/workspace-templates/jupyter-notebook/templates/_helpers.tpl
@@ -1,0 +1,59 @@
+{{/*
+Create a safe resource name that respects Kubernetes naming limits.
+This helper ensures the final name doesn't exceed 63 characters.
+Usage: {{ include "jupyter-notebook.safeName" (dict "base" .Values.deploymentName "suffix" "notebook-configmap") }}
+*/}}
+{{- define "jupyter-notebook.safeName" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $fullSuffix := printf "-%s" $suffix -}}
+{{- $maxBaseLength := sub 63 (len $fullSuffix) -}}
+{{- if gt (len $base) $maxBaseLength -}}
+{{- $truncatedBase := $base | trunc (int $maxBaseLength) -}}
+{{- printf "%s%s" $truncatedBase $fullSuffix -}}
+{{- else -}}
+{{- printf "%s%s" $base $fullSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a safe deployment name specifically for jupyter-notebook resources.
+*/}}
+{{- define "jupyter-notebook.deploymentName" -}}
+{{- include "jupyter-notebook.safeName" (dict "base" .Values.deploymentName "suffix" "notebook") -}}
+{{- end -}}
+
+{{/*
+Create a safe configmap name specifically for jupyter-notebook configmap.
+*/}}
+{{- define "jupyter-notebook.configmapName" -}}
+{{- include "jupyter-notebook.safeName" (dict "base" .Values.deploymentName "suffix" "nb-configmap") -}}
+{{- end -}}
+
+{{/*
+Create a safe PVC name specifically for jupyter-notebook storage.
+*/}}
+{{- define "jupyter-notebook.pvcName" -}}
+{{- include "jupyter-notebook.safeName" (dict "base" .Values.deploymentName "suffix" "nb-pvc") -}}
+{{- end -}}
+
+{{/*
+Create a safe service name specifically for jupyter-notebook service.
+*/}}
+{{- define "jupyter-notebook.serviceName" -}}
+{{- include "jupyter-notebook.safeName" (dict "base" .Values.deploymentName "suffix" "notebook") -}}
+{{- end -}}
+
+{{/*
+Create a safe volume name for notebook storage.
+*/}}
+{{- define "jupyter-notebook.storageVolumeName" -}}
+{{- include "jupyter-notebook.safeName" (dict "base" .Values.deploymentName "suffix" "nb-storage") -}}
+{{- end -}}
+
+{{/*
+Create a safe volume name for configmap volume.
+*/}}
+{{- define "jupyter-notebook.configmapVolumeName" -}}
+{{- include "jupyter-notebook.safeName" (dict "base" .Values.deploymentName "suffix" "cm-volume") -}}
+{{- end -}}

--- a/workspace-templates/jupyter-notebook/templates/configmap.yaml
+++ b/workspace-templates/jupyter-notebook/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.deploymentName }}-notebook-configmap
+  name: {{ include "jupyter-notebook.configmapName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
 data:
   jupyter_server_config.py: |

--- a/workspace-templates/jupyter-notebook/templates/deployment.yaml
+++ b/workspace-templates/jupyter-notebook/templates/deployment.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.deploymentName }}-notebook
+  name: {{ include "jupyter-notebook.deploymentName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}-notebook
+    app: {{ include "jupyter-notebook.deploymentName" . }}
 spec:
   replicas: {{ .Values.deploymentNumReplicas }}
   selector:
     matchLabels:
-      app: {{ .Values.deploymentName }}-notebook
+      app: {{ include "jupyter-notebook.deploymentName" . }}
   template:
     metadata:
       labels:
-        app: {{ .Values.deploymentName }}-notebook
+        app: {{ include "jupyter-notebook.deploymentName" . }}
     spec:
       securityContext:
         fsGroup: 0
@@ -21,12 +21,12 @@ spec:
       runtimeClassName: nvidia
 {{- end }}
       containers:
-        - name: {{ .Values.deploymentName }}-notebook
+        - name: {{ include "jupyter-notebook.deploymentName" . }}
           image: {{ .Values.deploymentImage }}
           volumeMounts:
-            - name: {{ .Values.deploymentName }}-notebook-storage
+            - name: {{ include "jupyter-notebook.storageVolumeName" . }}
               mountPath: /tf
-            - name: {{ .Values.deploymentName }}-configmap-volume
+            - name: {{ include "jupyter-notebook.configmapVolumeName" . }}
               mountPath: /root/.jupyter/jupyter_server_config.py
               subPath: jupyter_server_config.py
           resources:
@@ -44,9 +44,9 @@ spec:
             - containerPort: 8888
               name: notebook
       volumes:
-        - name: {{ .Values.deploymentName }}-notebook-storage
+        - name: {{ include "jupyter-notebook.storageVolumeName" . }}
           persistentVolumeClaim:
-            claimName: {{ .Values.deploymentName }}-notebook-pvc
-        - name: {{ .Values.deploymentName }}-configmap-volume
+            claimName: {{ include "jupyter-notebook.pvcName" . }}
+        - name: {{ include "jupyter-notebook.configmapVolumeName" . }}
           configMap:
-            name: {{ .Values.deploymentName }}-notebook-configmap
+            name: {{ include "jupyter-notebook.configmapName" . }}

--- a/workspace-templates/jupyter-notebook/templates/pvc.yaml
+++ b/workspace-templates/jupyter-notebook/templates/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.deploymentName }}-notebook-pvc
+  name: {{ include "jupyter-notebook.pvcName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
 spec:
   accessModes:

--- a/workspace-templates/jupyter-notebook/templates/svc.yaml
+++ b/workspace-templates/jupyter-notebook/templates/svc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deploymentName }}-notebook
+  name: {{ include "jupyter-notebook.serviceName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}-notebook
+    app: {{ include "jupyter-notebook.deploymentName" . }}
   annotations:
     workspace.exalsius.ai/access-info: "true"
     workspace.exalsius.ai/access-type: "nodeport"
@@ -17,4 +17,4 @@ spec:
       name: http
       targetPort: 8888
   selector:
-    app: {{ .Values.deploymentName }}-notebook
+    app: {{ include "jupyter-notebook.deploymentName" . }}

--- a/workspace-templates/marimo/templates/_helpers.tpl
+++ b/workspace-templates/marimo/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Create a safe resource name that respects Kubernetes naming limits.
+This helper ensures the final name doesn't exceed 63 characters.
+Usage: {{ include "marimo.safeName" (dict "base" .Values.deploymentName "suffix" "marimo") }}
+*/}}
+{{- define "marimo.safeName" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $fullSuffix := printf "-%s" $suffix -}}
+{{- $maxBaseLength := sub 63 (len $fullSuffix) -}}
+{{- if gt (len $base) $maxBaseLength -}}
+{{- $truncatedBase := $base | trunc (int $maxBaseLength) -}}
+{{- printf "%s%s" $truncatedBase $fullSuffix -}}
+{{- else -}}
+{{- printf "%s%s" $base $fullSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a safe deployment name specifically for marimo resources.
+*/}}
+{{- define "marimo.deploymentName" -}}
+{{- include "marimo.safeName" (dict "base" .Values.deploymentName "suffix" "marimo") -}}
+{{- end -}}
+
+{{/*
+Create a safe service name specifically for marimo service.
+*/}}
+{{- define "marimo.serviceName" -}}
+{{- include "marimo.safeName" (dict "base" .Values.deploymentName "suffix" "marimo") -}}
+{{- end -}}
+
+{{/*
+Create a safe PVC name specifically for marimo storage.
+*/}}
+{{- define "marimo.pvcName" -}}
+{{- include "marimo.safeName" (dict "base" .Values.deploymentName "suffix" "marimo-pvc") -}}
+{{- end -}}
+
+{{/*
+Create a safe secret name specifically for marimo secret.
+*/}}
+{{- define "marimo.secretName" -}}
+{{- include "marimo.safeName" (dict "base" .Values.deploymentName "suffix" "marimo-secret") -}}
+{{- end -}}
+
+{{/*
+Create a safe volume name for marimo storage.
+*/}}
+{{- define "marimo.storageVolumeName" -}}
+{{- include "marimo.safeName" (dict "base" .Values.deploymentName "suffix" "marimo-storage") -}}
+{{- end -}}

--- a/workspace-templates/marimo/templates/deployment.yaml
+++ b/workspace-templates/marimo/templates/deployment.yaml
@@ -1,19 +1,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.deploymentName }}-marimo
+  name: {{ include "marimo.deploymentName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}-marimo
+    app: {{ include "marimo.deploymentName" . }}
 spec:
   replicas: {{ .Values.deploymentNumReplicas }}
   selector:
     matchLabels:
-      app: {{ .Values.deploymentName }}-marimo
+      app: {{ include "marimo.deploymentName" . }}
   template:
     metadata:
       labels:
-        app: {{ .Values.deploymentName }}-marimo
+        app: {{ include "marimo.deploymentName" . }}
     spec:
       securityContext:
         fsGroup: 0
@@ -21,13 +21,13 @@ spec:
       runtimeClassName: nvidia
 {{- end }}
       containers:
-        - name: {{ .Values.deploymentName }}-marimo
+        - name: {{ include "marimo.deploymentName" . }}
           image: {{ .Values.deploymentImage }}
           env:
             - name: TOKEN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.deploymentName }}-marimo-secret
+                  name: {{ include "marimo.secretName" . }}
                   key: TOKEN_PASSWORD
           command: ["sh", "-c"]
           args:
@@ -35,7 +35,7 @@ spec:
               marimo edit --token --token-password="${TOKEN_PASSWORD}"
               -p 8080 --host 0.0.0.0
           volumeMounts:
-            - name: {{ .Values.deploymentName }}-marimo-storage
+            - name: {{ include "marimo.storageVolumeName" . }}
               mountPath: /data
           resources:
             requests:
@@ -52,6 +52,6 @@ spec:
             - containerPort: 8080
               name: marimo
       volumes:
-        - name: {{ .Values.deploymentName }}-marimo-storage
+        - name: {{ include "marimo.storageVolumeName" . }}
           persistentVolumeClaim:
-            claimName: {{ .Values.deploymentName }}-marimo-pvc
+            claimName: {{ include "marimo.pvcName" . }}

--- a/workspace-templates/marimo/templates/pvc.yaml
+++ b/workspace-templates/marimo/templates/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.deploymentName }}-marimo-pvc
+  name: {{ include "marimo.pvcName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
 spec:
   accessModes:

--- a/workspace-templates/marimo/templates/secret.yaml
+++ b/workspace-templates/marimo/templates/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.deploymentName }}-marimo-secret
+  name: {{ include "marimo.secretName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
 type: Opaque
 stringData:

--- a/workspace-templates/marimo/templates/svc.yaml
+++ b/workspace-templates/marimo/templates/svc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deploymentName }}-marimo
+  name: {{ include "marimo.serviceName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}-marimo
+    app: {{ include "marimo.deploymentName" . }}
   annotations:
     workspace.exalsius.ai/access-info: "true"
     workspace.exalsius.ai/access-type: "nodeport"
@@ -17,4 +17,4 @@ spec:
       name: http
       targetPort: 8080
   selector:
-    app: {{ .Values.deploymentName }}-marimo
+    app: {{ include "marimo.deploymentName" . }}

--- a/workspace-templates/performance-profiling/templates/_helpers.tpl
+++ b/workspace-templates/performance-profiling/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Create a safe resource name that respects Kubernetes naming limits.
+This helper ensures the final name doesn't exceed 63 characters.
+Usage: {{ include "performance-profiling.safeName" (dict "base" .Values.deploymentName "suffix" "profiling-config") }}
+*/}}
+{{- define "performance-profiling.safeName" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $fullSuffix := printf "-%s" $suffix -}}
+{{- $maxBaseLength := sub 63 (len $fullSuffix) -}}
+{{- if gt (len $base) $maxBaseLength -}}
+{{- $truncatedBase := $base | trunc (int $maxBaseLength) -}}
+{{- printf "%s%s" $truncatedBase $fullSuffix -}}
+{{- else -}}
+{{- printf "%s%s" $base $fullSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a safe job name specifically for performance-profiling resources.
+*/}}
+{{- define "performance-profiling.jobName" -}}
+{{- .Values.deploymentName | trunc 63 -}}
+{{- end -}}
+
+{{/*
+Create a safe configmap name specifically for performance-profiling configmap.
+*/}}
+{{- define "performance-profiling.configmapName" -}}
+{{- include "performance-profiling.safeName" (dict "base" .Values.deploymentName "suffix" "prof-config") -}}
+{{- end -}}

--- a/workspace-templates/performance-profiling/templates/configmap.yaml
+++ b/workspace-templates/performance-profiling/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.deploymentName }}-profiling-config
+  name: {{ include "performance-profiling.configmapName" . }}
   namespace: {{ .Values.deploymentNamespace }}
 data:
   profiling_config.json: |

--- a/workspace-templates/performance-profiling/templates/profiling-job.yaml
+++ b/workspace-templates/performance-profiling/templates/profiling-job.yaml
@@ -1,10 +1,10 @@
 apiVersion: batch.volcano.sh/v1alpha1
 kind: Job
 metadata:
-  name: {{ .Values.deploymentName }}
+  name: {{ include "performance-profiling.jobName" . }}
   namespace: {{ .Values.deploymentNamespace }}
   labels:
-    job-name: {{ .Values.deploymentName }}
+    job-name: {{ include "performance-profiling.jobName" . }}
 spec:
   maxRetry: 3
   minAvailable: {{ .Values.nodes }}
@@ -27,9 +27,9 @@ spec:
       template:
         metadata:
           annotations:
-            scheduling.k8s.io/group-name: {{ .Values.deploymentName }}
+            scheduling.k8s.io/group-name: {{ include "performance-profiling.jobName" . }}
           labels:
-            job-name: {{ .Values.deploymentName }}
+            job-name: {{ include "performance-profiling.jobName" . }}
             role: master
         spec:
           containers:
@@ -40,7 +40,7 @@ spec:
               name: master
               env:
                 - name: VOLCANO_JOB_NAME
-                  value: {{ .Values.deploymentName }}
+                  value: {{ include "performance-profiling.jobName" . }}
                 {{ range .Values.extraEnvironmentVariables }}
                 - name: {{ .name }}
                   value: {{ .value }}
@@ -63,7 +63,7 @@ spec:
           volumes:
             - name: profiling-config
               configMap:
-                name: {{ .Values.deploymentName }}-profiling-config
+                name: {{ include "performance-profiling.configmapName" . }}
           restartPolicy: OnFailure
           runtimeClassName: nvidia
     - maxRetry: 3
@@ -73,9 +73,9 @@ spec:
       template:
         metadata:
           annotations:
-            scheduling.k8s.io/group-name: {{ .Values.deploymentName }}
+            scheduling.k8s.io/group-name: {{ include "performance-profiling.jobName" . }}
           labels:
-            job-name: {{ .Values.deploymentName }}
+            job-name: {{ include "performance-profiling.jobName" . }}
             role: worker
         spec:
           containers:
@@ -86,7 +86,7 @@ spec:
               name: worker
               env:
                 - name: VOLCANO_JOB_NAME
-                  value: {{ .Values.deploymentName }}
+                  value: {{ include "performance-profiling.jobName" . }}
                 {{ range .Values.extraEnvironmentVariables }}
                 - name: {{ .name }}
                   value: {{ .value }}
@@ -109,6 +109,6 @@ spec:
           volumes:
             - name: profiling-config
               configMap:
-                name: {{ .Values.deploymentName }}-profiling-config
+                name: {{ include "performance-profiling.configmapName" . }}
           restartPolicy: OnFailure
           runtimeClassName: nvidia

--- a/workspace-templates/ray-llm-service/templates/_helpers.tpl
+++ b/workspace-templates/ray-llm-service/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Create a safe resource name that respects Kubernetes naming limits.
+This helper ensures the final name doesn't exceed 63 characters.
+Usage: {{ include "ray-llm-service.safeName" (dict "base" .Values.deploymentName "suffix" "ray-service") }}
+*/}}
+{{- define "ray-llm-service.safeName" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $fullSuffix := printf "-%s" $suffix -}}
+{{- $maxBaseLength := sub 63 (len $fullSuffix) -}}
+{{- if gt (len $base) $maxBaseLength -}}
+{{- $truncatedBase := $base | trunc (int $maxBaseLength) -}}
+{{- printf "%s%s" $truncatedBase $fullSuffix -}}
+{{- else -}}
+{{- printf "%s%s" $base $fullSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a safe deployment name specifically for ray-llm-service resources.
+*/}}
+{{- define "ray-llm-service.deploymentName" -}}
+{{- include "ray-llm-service.safeName" (dict "base" .Values.deploymentName "suffix" "ray-service") -}}
+{{- end -}}
+
+{{/*
+Create a safe configmap name specifically for ray-llm-service configmap.
+*/}}
+{{- define "ray-llm-service.configmapName" -}}
+{{- include "ray-llm-service.safeName" (dict "base" .Values.deploymentName "suffix" "ray-config") -}}
+{{- end -}}
+
+{{/*
+Create a safe secret name specifically for ray-llm-service secret.
+*/}}
+{{- define "ray-llm-service.secretName" -}}
+{{- include "ray-llm-service.safeName" (dict "base" .Values.deploymentName "suffix" "ray-hf-secret") -}}
+{{- end -}}
+
+{{/*
+Create a safe service name for ray standalone serve service.
+*/}}
+{{- define "ray-llm-service.serveServiceName" -}}
+{{- include "ray-llm-service.safeName" (dict "base" .Values.deploymentName "suffix" "ray-serve-svc") -}}
+{{- end -}}
+
+{{/*
+Create a safe service name for ray standalone dashboard service.
+*/}}
+{{- define "ray-llm-service.dashboardServiceName" -}}
+{{- include "ray-llm-service.safeName" (dict "base" .Values.deploymentName "suffix" "ray-dash-svc") -}}
+{{- end -}}

--- a/workspace-templates/ray-llm-service/templates/configmap.yaml
+++ b/workspace-templates/ray-llm-service/templates/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.deploymentName }}-ray-config
+  name: {{ include "ray-llm-service.configmapName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
 data:
   llm_deployment.py: |

--- a/workspace-templates/ray-llm-service/templates/deployment.yaml
+++ b/workspace-templates/ray-llm-service/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
-  name: {{ .Values.deploymentName }}-ray-service
+  name: {{ include "ray-llm-service.deploymentName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
 spec:
   serveConfigV2: |
@@ -37,7 +37,7 @@ spec:
           labels:
             component.type: head
             component.subtype: serve-endpoint
-            ray.name: {{ .Values.deploymentName }}-ray-service
+            ray.name: {{ include "ray-llm-service.deploymentName" . }}
         spec:
 {{- if and .Values.gpuCount (gt (int .Values.gpuCount) 0) }}
           runtimeClassName: nvidia
@@ -65,7 +65,7 @@ spec:
               - name: HUGGING_FACE_HUB_TOKEN
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.deploymentName }}-ray-hf-secret
+                    name: {{ include "ray-llm-service.secretName" . }}
                     key: hf_api_token
 {{- end }}
               resources:
@@ -85,5 +85,5 @@ spec:
           volumes:
           - name: ray-head-files
             configMap:
-              name: {{ .Values.deploymentName }}-ray-config
+              name: {{ include "ray-llm-service.configmapName" . }}
   

--- a/workspace-templates/ray-llm-service/templates/secret.yaml
+++ b/workspace-templates/ray-llm-service/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.deploymentName }}-ray-hf-secret
+  name: {{ include "ray-llm-service.secretName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
 data:
   hf_api_token: {{ .Values.huggingfaceToken | b64enc }}

--- a/workspace-templates/ray-llm-service/templates/svc.yaml
+++ b/workspace-templates/ray-llm-service/templates/svc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deploymentName }}-ray-standalone-serve-service
+  name: {{ include "ray-llm-service.serveServiceName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}-ray-standalone-serve-service
+    app: {{ include "ray-llm-service.serveServiceName" . }}
   annotations:
     workspace.exalsius.ai/access-info: "true"
     workspace.exalsius.ai/access-type: "nodeport"
@@ -18,15 +18,15 @@ spec:
       targetPort: 8000
   selector:
     component.subtype: serve-endpoint
-    ray.name: {{ .Values.deploymentName }}-ray-service
+    ray.name: {{ include "ray-llm-service.deploymentName" . }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deploymentName }}-ray-standalone-dashboard-service
+  name: {{ include "ray-llm-service.dashboardServiceName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}-ray-standalone-dashboard-service
+    app: {{ include "ray-llm-service.dashboardServiceName" . }}
   annotations:
     workspace.exalsius.ai/access-info: "true"
     workspace.exalsius.ai/access-type: "nodeport"
@@ -40,4 +40,4 @@ spec:
       targetPort: 8265
   selector:
     component.type: head
-    ray.name: {{ .Values.deploymentName }}-ray-service
+    ray.name: {{ include "ray-llm-service.deploymentName" . }}

--- a/workspace-templates/test-workspace/templates/_helpers.tpl
+++ b/workspace-templates/test-workspace/templates/_helpers.tpl
@@ -1,0 +1,31 @@
+{{/*
+Create a safe resource name that respects Kubernetes naming limits.
+This helper ensures the final name doesn't exceed 63 characters.
+Usage: {{ include "test-workspace.safeName" (dict "base" .Values.deploymentName "suffix" "test") }}
+*/}}
+{{- define "test-workspace.safeName" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $fullSuffix := printf "-%s" $suffix -}}
+{{- $maxBaseLength := sub 63 (len $fullSuffix) -}}
+{{- if gt (len $base) $maxBaseLength -}}
+{{- $truncatedBase := $base | trunc (int $maxBaseLength) -}}
+{{- printf "%s%s" $truncatedBase $fullSuffix -}}
+{{- else -}}
+{{- printf "%s%s" $base $fullSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a safe deployment name specifically for test-workspace resources.
+*/}}
+{{- define "test-workspace.deploymentName" -}}
+{{- include "test-workspace.safeName" (dict "base" .Values.deploymentName "suffix" "test") -}}
+{{- end -}}
+
+{{/*
+Create a safe service name specifically for test-workspace service.
+*/}}
+{{- define "test-workspace.serviceName" -}}
+{{- include "test-workspace.safeName" (dict "base" .Values.deploymentName "suffix" "test") -}}
+{{- end -}}

--- a/workspace-templates/test-workspace/templates/deployment.yaml
+++ b/workspace-templates/test-workspace/templates/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.deploymentName }}
+  name: {{ include "test-workspace.deploymentName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}
+    app: {{ include "test-workspace.deploymentName" . }}
 spec:
   replicas: {{ .Values.deploymentNumReplicas }}
   selector:
@@ -16,7 +16,7 @@ spec:
         app: {{ .Values.deploymentName }}
     spec:
       containers:
-        - name: {{ .Values.deploymentName }}
+        - name: {{ include "test-workspace.deploymentName" . }}
           image: {{ .Values.deploymentImage }}
           command: ["sleep", "infinity"]
           resources:

--- a/workspace-templates/test-workspace/templates/svc.yaml
+++ b/workspace-templates/test-workspace/templates/svc.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.deploymentName }}
+  name: {{ include "test-workspace.serviceName" . }}
   namespace: {{ .Values.deploymentNamespace | default "default" }}
   labels:
-    app: {{ .Values.deploymentName }}
+    app: {{ include "test-workspace.deploymentName" . }}
   annotations:
     workspace.exalsius.ai/access-info: "true"
     workspace.exalsius.ai/access-type: "nodeport"
@@ -17,4 +17,4 @@ spec:
       name: http
       targetPort: 8080
   selector:
-    app: {{ .Values.deploymentName }}
+    app: {{ include "test-workspace.deploymentName" . }}

--- a/workspace-templates/vscode-devcontainer/templates/_helpers.tpl
+++ b/workspace-templates/vscode-devcontainer/templates/_helpers.tpl
@@ -1,0 +1,38 @@
+{{/*
+Create a safe resource name that respects Kubernetes naming limits.
+This helper ensures the final name doesn't exceed 63 characters.
+Usage: {{ include "vscode-devcontainer.safeName" (dict "base" .Values.deploymentName "suffix" "code") }}
+*/}}
+{{- define "vscode-devcontainer.safeName" -}}
+{{- $base := .base -}}
+{{- $suffix := .suffix -}}
+{{- $fullSuffix := printf "-%s" $suffix -}}
+{{- $maxBaseLength := sub 63 (len $fullSuffix) -}}
+{{- if gt (len $base) $maxBaseLength -}}
+{{- $truncatedBase := $base | trunc (int $maxBaseLength) -}}
+{{- printf "%s%s" $truncatedBase $fullSuffix -}}
+{{- else -}}
+{{- printf "%s%s" $base $fullSuffix -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a safe deployment name specifically for vscode-devcontainer resources.
+*/}}
+{{- define "vscode-devcontainer.deploymentName" -}}
+{{- include "vscode-devcontainer.safeName" (dict "base" .Values.deploymentName "suffix" "code") -}}
+{{- end -}}
+
+{{/*
+Create a safe PVC name specifically for vscode-devcontainer storage.
+*/}}
+{{- define "vscode-devcontainer.pvcName" -}}
+{{- include "vscode-devcontainer.safeName" (dict "base" .Values.deploymentName "suffix" "code-pvc") -}}
+{{- end -}}
+
+{{/*
+Create a safe volume name for vscode-devcontainer storage.
+*/}}
+{{- define "vscode-devcontainer.storageVolumeName" -}}
+{{- include "vscode-devcontainer.safeName" (dict "base" .Values.deploymentName "suffix" "code-storage") -}}
+{{- end -}}

--- a/workspace-templates/vscode-devcontainer/templates/deployment.yaml
+++ b/workspace-templates/vscode-devcontainer/templates/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.deploymentName }}-code
+  name: {{ include "vscode-devcontainer.deploymentName" . }}
   namespace: {{ .Values.deploymentNamespace }}
   labels:
-    app: {{ .Values.deploymentName }}-code
+    app: {{ include "vscode-devcontainer.deploymentName" . }}
 spec:
   replicas: {{ .Values.deploymentNumReplicas }}
   selector:
@@ -23,7 +23,7 @@ spec:
           image: {{ .Values.deploymentImage }}
           command: ["sleep", "infinity"]
           volumeMounts:
-            - name: {{ .Values.deploymentName }}-code-storage
+            - name: {{ include "vscode-devcontainer.storageVolumeName" . }}
               mountPath: /workspace
             - name: dshm
               mountPath: /dev/shm
@@ -39,9 +39,9 @@ spec:
               nvidia.com/gpu: {{ .Values.gpuCount }}
               ephemeral-storage: {{ .Values.ephemeralStorageGb }}Gi
       volumes:
-        - name: {{ .Values.deploymentName }}-code-storage
+        - name: {{ include "vscode-devcontainer.storageVolumeName" . }}
           persistentVolumeClaim:
-            claimName: {{ .Values.deploymentName }}-code-pvc
+            claimName: {{ include "vscode-devcontainer.pvcName" . }}
         - name: dshm
           emptyDir:
             medium: Memory

--- a/workspace-templates/vscode-devcontainer/templates/pvc.yaml
+++ b/workspace-templates/vscode-devcontainer/templates/pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.deploymentName }}-code-pvc
+  name: {{ include "vscode-devcontainer.pvcName" . }}
   namespace: {{ .Values.deploymentNamespace }}
 spec:
   accessModes:


### PR DESCRIPTION
This PR implements helper methods across all workspace charts to automatically truncate resource names that exceed Kubernetes 63-character limit for resource identifiers. This ensures all generated resources (deployments, services, 
configmaps, etc.) remain valid and deployable regardless of release name length.