### PR TITLE
fix(workspaces): handle unsupported display driver / cuda driver combination in llm-d-cuda image

### DIFF
--- a/workspace-templates/llm-inference/llm-d-model/values.yaml
+++ b/workspace-templates/llm-inference/llm-d-model/values.yaml
@@ -71,7 +71,8 @@ ms:
         interval: "30s"
     containers:
     - name: "vllm"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.5.0
+      # image: ghcr.io/llm-d/llm-d-cuda:v0.5.0
+      image: ghcr.io/llm-d/llm-d-cuda-dev:sha-4f5cdd5 # fixes an issue with the v0.5.0 image, as discussed here: https://github.com/llm-d/llm-d/issues/706
       modelCommand: vllmServe
       args:
         - "--disable-uvicorn-access-log"


### PR DESCRIPTION
There has been a reported problem in llm-d-cuda v0.5.0 image. A quick fix has been already released under a docker image development tag (see [here](https://github.com/llm-d/llm-d/issues/706)). Once a proper release has been published, we will update the image tag accordingly.