### PR TITLE
fix(llm-inference): make mount of api-key optional

### DIFF
--- a/workspace-templates/llm-inference/llm-d-model/values.yaml
+++ b/workspace-templates/llm-inference/llm-d-model/values.yaml
@@ -101,6 +101,7 @@ ms:
             secretKeyRef:
               name: llm-d-model-auth-details
               key: VLLM_API_KEY
+              optional: true # in case the lookup fails or the api-key is an empty string, we do not want the deployment to fail
       ports:
         - containerPort: 8000
           name: vllm


### PR DESCRIPTION
Added optional field to secretKeyRef for VLLM_API_KEY to prevent deployment failure if the key is missing or empty.