### PR TITLE
chore: render workspace manifests

### DIFF
--- a/examples/devpod/0.2.0/example-workspacedeployment.yaml
+++ b/examples/devpod/0.2.0/example-workspacedeployment.yaml
@@ -1,0 +1,34 @@
+# Example WorkspaceDeployment (user intent — applied by an end user).
+#
+# TEMPLATE — rendered at release time into
+#   examples/devpod/0.2.0/example-workspacedeployment.yaml
+# Placeholders 0.2.0 / 0-2-0 are substituted from Chart.yaml.
+#
+# Apply:  kubectl apply -f example-workspacedeployment.yaml
+# Watch:  kubectl get wsd -n kcm-system -w
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceDeployment
+metadata:
+  name: my-devpod
+  namespace: kcm-system
+spec:
+  workspaceClassRef: devpod-0-2-0
+  clusterDeploymentRef:
+    name: default-child-adopted          # Colony "default" + cluster "child-adopted"
+    namespace: kcm-system
+  resources:
+    perReplica:
+      cpu: "8"
+      memory: "16Gi"
+      storage: "100Gi"
+      # GPU is optional. To run CPU-only, drop gpuCount + gpuNodeSelector.
+      gpuCount: 1
+      # Pick any GPU node by a raw vendor label — copy the value straight from
+      # the Colony GPU inventory's offering.selector (works for NVIDIA or AMD):
+      #   kubectl get colony <name> -o jsonpath='{.status.gpuInventory}' | jq
+      gpuNodeSelector:
+        nvidia.com/gpu.product: "NVIDIA-L40"
+  values:
+    sshPassword: "change-me-please"
+    # sshPublicKey: |
+    #   ssh-ed25519 AAAA... user@host

--- a/examples/jupyter-notebook/0.3.0/example-workspacedeployment.yaml
+++ b/examples/jupyter-notebook/0.3.0/example-workspacedeployment.yaml
@@ -1,0 +1,35 @@
+# Example WorkspaceDeployment (user intent — applied by an end user).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/jupyter-notebook/0.3.0/example-workspacedeployment.yaml
+# Placeholders 0.3.0 / 0-3-0 are substituted from Chart.yaml.
+#
+# A WorkspaceDeployment pins an exact WorkspaceClass version. Upgrade
+# or rollback = change workspaceClassRef to a different version.
+#
+# Apply:  kubectl apply -f example-workspacedeployment.yaml
+# Watch:  kubectl get wsd -n kcm-system -w
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceDeployment
+metadata:
+  name: my-notebook
+  namespace: kcm-system
+spec:
+  workspaceClassRef: jupyter-notebook-0-3-0
+  clusterDeploymentRef:
+    name: default-child-adopted          # Colony "default" + cluster "child-adopted"
+    namespace: kcm-system
+  resources:
+    perReplica:
+      cpu: "8"
+      memory: "16Gi"
+      storage: "50Gi"
+      # GPU is optional. To run CPU-only, drop gpuCount + gpuNodeSelector.
+      gpuCount: 1
+      # Pick any GPU node by a raw vendor label — copy the value straight from
+      # the Colony GPU inventory's offering.selector (works for NVIDIA or AMD):
+      #   kubectl get colony <name> -o jsonpath='{.status.gpuInventory}' | jq
+      gpuNodeSelector:
+        nvidia.com/gpu.product: "NVIDIA-L40"
+  values:
+    notebookPassword: "change-me-please"

--- a/examples/llm-d-model/0.3.0/example-workspacedeployment.yaml
+++ b/examples/llm-d-model/0.3.0/example-workspacedeployment.yaml
@@ -1,0 +1,96 @@
+# Example WorkspaceDeployment (user intent — applied by an end user).
+#
+# TEMPLATE — rendered at release time into
+#   examples/llm-d-model/0.3.0/example-workspacedeployment.yaml
+# Placeholders 0.3.0 / 0-3-0 are substituted from Chart.yaml.
+#
+# The operator auto-installs the llm-d-infra prerequisite on first use.
+#
+# Apply:  kubectl apply -f example-workspacedeployment.yaml
+# Watch:  kubectl get wsd -n kcm-system -w
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceDeployment
+metadata:
+  name: my-llm-model
+  namespace: kcm-system
+spec:
+  workspaceClassRef: llm-d-model-0-3-0
+  clusterDeploymentRef:
+    name: default-child-adopted          # Colony "default" + cluster "child-adopted"
+    namespace: kcm-system
+  resources:
+    perReplica:
+      cpu: "8"
+      memory: "16Gi"
+      storage: "50Gi"
+      # gpuCount drives vLLM tensor-parallelism (resourceInjection).
+      gpuCount: 1
+      # Pick a GPU node by a raw vendor label from the Colony GPU inventory:
+      #   kubectl get colony <name> -o jsonpath='{.status.gpuInventory}' | jq
+      gpuNodeSelector:
+        nvidia.com/gpu.product: "NVIDIA-L40"
+  values:
+    huggingfaceToken: "hf_replace_me"
+    inferenceApiKey: "api_key"
+    ms:
+      modelArtifacts:
+        uri: "hf://Qwen/Qwen3-1.7B"
+        name: "Qwen/Qwen3-1.7B"
+        # The model label must match the inference pool selector below.
+        labels:
+          llm-d.ai/model: Qwen3-1.7B
+      decode:
+        initContainers:
+        - name: uds-tokenizer
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          env:
+          - name: LOG_LEVEL
+            value: "DEBUG"
+          - name: PROBE_PORT
+            value: "8082"
+          ports:
+          - name: health
+            containerPort: 8082
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8082
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          volumeMounts:
+          - name: uds-socket
+            mountPath: /tmp/tokenizer
+        # For testing purposes it is often sufficient to use the vllm-simulation from llm-d project
+        containers:
+        - name: "vllm"
+          image: "ghcr.io/llm-d/llm-d-inference-sim:v0.8.2"
+          modelCommand: imageDefault
+          volumeMounts:
+          - name: metrics-volume
+            mountPath: /.config
+          - name: uds-socket
+            mountPath: /tmp/tokenizer
+        volumes:
+        - name: metrics-volume
+          emptyDir: {}
+        - name: uds-socket
+          emptyDir: {}
+        - name: torch-compile-cache
+          emptyDir: {}
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 20Gi
+    ip:
+      inferencePool:
+        modelServers:
+          matchLabels:
+            llm-d.ai/model: Qwen3-1.7B

--- a/examples/marimo/0.3.0/example-workspacedeployment.yaml
+++ b/examples/marimo/0.3.0/example-workspacedeployment.yaml
@@ -1,0 +1,35 @@
+# Example WorkspaceDeployment (user intent — applied by an end user).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/marimo/0.3.0/example-workspacedeployment.yaml
+# Placeholders 0.3.0 / 0-3-0 are substituted from Chart.yaml.
+#
+# A WorkspaceDeployment pins an exact WorkspaceClass version. Upgrade
+# or rollback = change workspaceClassRef to a different version.
+#
+# Apply:  kubectl apply -f example-workspacedeployment.yaml
+# Watch:  kubectl get wsd -n kcm-system -w
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceDeployment
+metadata:
+  name: my-marimo
+  namespace: kcm-system
+spec:
+  workspaceClassRef: marimo-0-3-0
+  clusterDeploymentRef:
+    name: default-child-adopted          # Colony "default" + cluster "child-adopted"
+    namespace: kcm-system
+  resources:
+    perReplica:
+      cpu: "8"
+      memory: "16Gi"
+      storage: "50Gi"
+      # GPU is optional. To run CPU-only, drop gpuCount + gpuNodeSelector.
+      gpuCount: 1
+      # Pick any GPU node by a raw vendor label — copy the value straight from
+      # the Colony GPU inventory's offering.selector (works for NVIDIA or AMD):
+      #   kubectl get colony <name> -o jsonpath='{.status.gpuInventory}' | jq
+      gpuNodeSelector:
+        nvidia.com/gpu.product: "NVIDIA-L40"
+  values:
+    tokenPassword: "change-me-please"

--- a/manifests/devpod/0.2.0/servicetemplate.yaml
+++ b/manifests/devpod/0.2.0/servicetemplate.yaml
@@ -1,0 +1,28 @@
+# Workspace ServiceTemplate (management-cluster CR).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/devpod/0.2.0/servicetemplate.yaml
+# Placeholders 0.2.0 / 0-2-0 are substituted from Chart.yaml.
+#
+# One ServiceTemplate wraps exactly one immutable chart version.
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplate
+metadata:
+  name: devpod-0-2-0
+  namespace: kcm-system
+  labels:
+    app: devpod
+    template: workspace
+    workspaces.exalsius.ai/template: devpod
+    workspaces.exalsius.ai/version: "0.2.0"
+spec:
+  helm:
+    chartSpec:
+      chart: devpod
+      version: "0.2.0"
+      interval: 10m
+      sourceRef:
+        # HelmRepository must live in the same namespace (kcm-system);
+        # k0rdent's schema has no sourceRef.namespace.
+        kind: HelmRepository
+        name: exalsius-workspace-hub

--- a/manifests/devpod/0.2.0/workspaceclass.yaml
+++ b/manifests/devpod/0.2.0/workspaceclass.yaml
@@ -1,0 +1,52 @@
+# Workspace catalog entry (management-cluster CR).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/devpod/0.2.0/workspaceclass.yaml
+# Placeholders 0.2.0 / 0-2-0 are substituted from Chart.yaml.
+#
+# A single-user remote development container reached over SSH. gpuType /
+# gpuNodeSelector are intentionally NOT set here — they are per-deployment,
+# cluster-dependent choices (the operator rejects them on a class). The default
+# is CPU-only (gpuCount 0); a deployment opts into a GPU.
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceClass
+metadata:
+  name: devpod-0-2-0
+  labels:
+    workspaces.exalsius.ai/template: devpod
+    workspaces.exalsius.ai/version: "0.2.0"
+spec:
+  displayName: "Dev Pod"
+  description: >-
+    Single-user remote development container reached over SSH (Remote-SSH from
+    VS Code, Cursor, or JetBrains). One framework-free image runs on CPU, NVIDIA,
+    or AMD ROCm nodes; install PyTorch (cuda/rocm) inside as needed.
+  serviceTemplate:
+    name: devpod-0-2-0
+    namespace: kcm-system
+  defaultResources:
+    replicas: 1
+    perReplica:
+      cpu: "4"
+      memory: "8Gi"
+      storage: "50Gi"
+      gpuCount: 0
+  accessEndpoints:
+    # SSH is raw TCP — the operator allocates a port from the gateway port pool
+    # and attaches a TCPRoute. Backed by the chart's "<release>-ssh" Service.
+    - name: ssh
+      protocol: SSH
+      port: 22
+      description: "SSH access for Remote-SSH editors"
+  userFacingConfig:
+    - helmValuePath: sshPassword
+      displayName: "SSH Password"
+      description: "Password for SSH login (user: root)"
+      type: secret
+      required: true
+    - helmValuePath: sshPublicKey
+      displayName: "SSH Public Key"
+      description: "Optional public key(s) for key-based SSH login, one per line"
+      type: string
+      required: false
+  deployTimeout: 15m

--- a/manifests/jupyter-notebook/0.3.0/servicetemplate.yaml
+++ b/manifests/jupyter-notebook/0.3.0/servicetemplate.yaml
@@ -1,0 +1,32 @@
+# Workspace ServiceTemplate (management-cluster CR).
+#
+# This is a TEMPLATE. At release time it is rendered into
+#   manifests/jupyter-notebook/0.3.0/servicetemplate.yaml
+# with the placeholders substituted from Chart.yaml (see exalsius/README.md):
+#   0.3.0         e.g. 1.0.0   (chart SemVer)
+#   0-3-0  e.g. 1-0-0   (dots -> dashes, DNS-1123 name)
+#
+# One ServiceTemplate wraps exactly one immutable chart version.
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplate
+metadata:
+  name: jupyter-notebook-0-3-0
+  namespace: kcm-system
+  labels:
+    app: jupyter-notebook
+    template: workspace
+    workspaces.exalsius.ai/template: jupyter-notebook
+    workspaces.exalsius.ai/version: "0.3.0"
+spec:
+  helm:
+    chartSpec:
+      chart: jupyter-notebook
+      version: "0.3.0"
+      interval: 10m
+      sourceRef:
+        # The HelmRepository must live in the same namespace as this
+        # ServiceTemplate (kcm-system); k0rdent's schema has no sourceRef.namespace.
+        # In prod it points at oci://ghcr.io/exalsius/exalsius-workspace-hub/charts;
+        # locally the harness creates a same-named one at the kind registry.
+        kind: HelmRepository
+        name: exalsius-workspace-hub

--- a/manifests/jupyter-notebook/0.3.0/workspaceclass.yaml
+++ b/manifests/jupyter-notebook/0.3.0/workspaceclass.yaml
@@ -1,0 +1,45 @@
+# Workspace catalog entry (management-cluster CR).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/jupyter-notebook/0.3.0/workspaceclass.yaml
+# Placeholders 0.3.0 / 0-3-0 are substituted from Chart.yaml.
+#
+# The class is version-named and immutable; a WorkspaceDeployment pins it
+# exactly, so a running workspace's definition never changes underneath it.
+# gpuType / gpuNodeSelector are intentionally NOT set here — they are
+# per-deployment, cluster-dependent choices (the operator rejects them on a
+# class). The default is CPU-only (gpuCount 0); a deployment opts into a GPU.
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceClass
+metadata:
+  name: jupyter-notebook-0-3-0
+  labels:
+    workspaces.exalsius.ai/template: jupyter-notebook
+    workspaces.exalsius.ai/version: "0.3.0"
+spec:
+  displayName: "Jupyter Notebook"
+  description: >-
+    Single-user Jupyter Notebook. One framework-free image runs on CPU, NVIDIA,
+    or AMD ROCm nodes; install PyTorch (cuda/rocm) inside the notebook as needed.
+  serviceTemplate:
+    name: jupyter-notebook-0-3-0
+    namespace: kcm-system
+  defaultResources:
+    replicas: 1
+    perReplica:
+      cpu: "4"
+      memory: "8Gi"
+      storage: "20Gi"
+      gpuCount: 0
+  accessEndpoints:
+    - name: http
+      protocol: HTTP
+      port: 80
+      description: "Jupyter Notebook web UI"
+  userFacingConfig:
+    - helmValuePath: notebookPassword
+      displayName: "Notebook Password"
+      description: "Password to access the Jupyter web UI"
+      type: secret
+      required: true
+  deployTimeout: 15m

--- a/manifests/llm-d-infra/0.3.0/servicetemplate.yaml
+++ b/manifests/llm-d-infra/0.3.0/servicetemplate.yaml
@@ -1,0 +1,31 @@
+# Workspace ServiceTemplate (management-cluster CR).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/llm-d-infra/0.3.0/servicetemplate.yaml
+# Placeholders 0.3.0 / 0-3-0 are substituted from Chart.yaml.
+#
+# This ServiceTemplate is the sole exalsius CR llm-d-infra ships: it is the
+# prerequisite that llm-d-model's WorkspaceClass references, auto-installed once
+# per cluster. Infra owns no WorkspaceClass — Open WebUI is routed per model via
+# each llm-d-model's "chat" endpoint (docs/adr/0006).
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplate
+metadata:
+  name: llm-d-infra-0-3-0
+  namespace: kcm-system
+  labels:
+    app: llm-d-infra
+    template: workspace
+    workspaces.exalsius.ai/template: llm-d-infra
+    workspaces.exalsius.ai/version: "0.3.0"
+spec:
+  helm:
+    chartSpec:
+      chart: llm-d-infra
+      version: "0.3.0"
+      interval: 10m
+      sourceRef:
+        # HelmRepository must live in the same namespace (kcm-system);
+        # k0rdent's schema has no sourceRef.namespace.
+        kind: HelmRepository
+        name: exalsius-workspace-hub

--- a/manifests/llm-d-model/0.3.0/servicetemplate.yaml
+++ b/manifests/llm-d-model/0.3.0/servicetemplate.yaml
@@ -1,0 +1,28 @@
+# Workspace ServiceTemplate (management-cluster CR).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/llm-d-model/0.3.0/servicetemplate.yaml
+# Placeholders 0.3.0 / 0-3-0 are substituted from Chart.yaml.
+#
+# One ServiceTemplate wraps exactly one immutable chart version.
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplate
+metadata:
+  name: llm-d-model-0-3-0
+  namespace: kcm-system
+  labels:
+    app: llm-d-model
+    template: workspace
+    workspaces.exalsius.ai/template: llm-d-model
+    workspaces.exalsius.ai/version: "0.3.0"
+spec:
+  helm:
+    chartSpec:
+      chart: llm-d-model
+      version: "0.3.0"
+      interval: 10m
+      sourceRef:
+        # HelmRepository must live in the same namespace (kcm-system);
+        # k0rdent's schema has no sourceRef.namespace.
+        kind: HelmRepository
+        name: exalsius-workspace-hub

--- a/manifests/llm-d-model/0.3.0/workspaceclass.yaml
+++ b/manifests/llm-d-model/0.3.0/workspaceclass.yaml
@@ -1,0 +1,96 @@
+# Workspace catalog entry (management-cluster CR).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/llm-d-model/0.3.0/workspaceclass.yaml
+# Placeholders substituted from Chart.yaml:
+#   0.3.0 / 0-3-0        this chart's version
+#   0.3.0 / 0-3-0  the sibling llm-d-infra chart's
+#       version (resolved by scripts/render-workspace-manifests.sh) — the
+#       prerequisite pins the exact infra ServiceTemplate version.
+#
+# Serves one model. The operator auto-installs the llm-d-infra prerequisite
+# (shared agentgateway + body-based routing + model discovery + Open WebUI) once
+# per ClusterDeployment and reuses it across all model workspaces. Each model
+# attaches to that shared gateway and exposes a per-workspace OpenAI endpoint via
+# an in-namespace redirect Service (see docs/adr/0002).
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceClass
+metadata:
+  name: llm-d-model-0-3-0
+  labels:
+    workspaces.exalsius.ai/template: llm-d-model
+    workspaces.exalsius.ai/version: "0.3.0"
+spec:
+  displayName: "LLM Inference (model)"
+  description: >-
+    Serve one LLM for inference with the llm-d stack (GAIE + vLLM). Exposes a
+    per-workspace OpenAI-compatible endpoint; auto-installs the shared llm-d-infra
+    prerequisite.
+  serviceTemplate:
+    name: llm-d-model-0-3-0
+    namespace: kcm-system
+  prerequisites:
+    - serviceTemplate:
+        name: llm-d-infra-0-3-0
+  defaultResources:
+    replicas: 1
+    perReplica:
+      cpu: "8"
+      memory: "16Gi"
+      storage: "50Gi"
+      # A model needs at least one accelerator; a deployment can raise this.
+      gpuCount: 1
+  # Umbrella mapping: route resolved _exalsius fields into the modelservice
+  # subchart. gpuCount drives vLLM tensor-parallelism (the subchart auto-derives
+  # the GPU resource request from it); gpuVendor selects the accelerator family.
+  # cpu/memory are not injected — the modelservice container resources live in a
+  # list path with no clean scalar target (see docs/adr/0002).
+  resourceInjection:
+    gpuCount:
+      - "ms.decode.parallelism.tensor"
+    gpuVendor:
+      - "ms.accelerator.type"
+    replicas:
+      - "ms.decode.replicas"
+  accessEndpoints:
+    - name: http
+      protocol: HTTP
+      port: 8000
+      description: "LLM Inference OpenAI-compatible REST API"
+    # A per-model front door to the single shared Open WebUI chat interface. Backed
+    # by the in-namespace "<release>-chat" redirect Service (llm-d-model templates)
+    # forwarding to the shared "llm-d-open-webui" Service in default. Open WebUI is
+    # routed here, per model, because it lives in the llm-d-infra prerequisite,
+    # which owns no WorkspaceClass and so cannot own a routed endpoint (adr/0006).
+    # Port 8000 (not 80): the backing "<release>-chat" Service must target the model
+    # pods' real port so the ambient global-service federation publishes endpoints
+    # (see llm-d-model templates/networking.yaml). The user-facing URL is
+    # hostname-based, so the port is invisible to users.
+    - name: chat
+      protocol: HTTP
+      port: 8000
+      description: "Open WebUI chat interface (shared across all models)"
+  userFacingConfig:
+    - helmValuePath: huggingfaceToken
+      displayName: "Hugging Face Token"
+      description: "Token for pulling the model from Hugging Face (stored in a Secret)"
+      type: secret
+      required: true
+    - helmValuePath: inferenceApiKey
+      displayName: "Inference API Key"
+      description: "Optional bearer token clients must present to call the model"
+      type: secret
+      required: false
+    - helmValuePath: ms.modelArtifacts.uri
+      displayName: "Model URI"
+      description: "Hugging Face model URI, e.g. hf://Qwen/Qwen3-1.7B"
+      type: string
+      required: true
+    - helmValuePath: ms.modelArtifacts.name
+      displayName: "Model Name"
+      description: "Served model name, e.g. Qwen/Qwen3-1.7B"
+      type: string
+      required: true
+  # vLLM/cuda images are large and the prerequisite installs a full stack.
+  deployTimeout: 30m
+  prerequisiteDeployTimeout: 20m

--- a/manifests/marimo/0.3.0/servicetemplate.yaml
+++ b/manifests/marimo/0.3.0/servicetemplate.yaml
@@ -1,0 +1,32 @@
+# Workspace ServiceTemplate (management-cluster CR).
+#
+# This is a TEMPLATE. At release time it is rendered into
+#   manifests/marimo/0.3.0/servicetemplate.yaml
+# with the placeholders substituted from Chart.yaml (see exalsius/README.md):
+#   0.3.0         e.g. 1.0.0   (chart SemVer)
+#   0-3-0  e.g. 1-0-0   (dots -> dashes, DNS-1123 name)
+#
+# One ServiceTemplate wraps exactly one immutable chart version.
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplate
+metadata:
+  name: marimo-0-3-0
+  namespace: kcm-system
+  labels:
+    app: marimo
+    template: workspace
+    workspaces.exalsius.ai/template: marimo
+    workspaces.exalsius.ai/version: "0.3.0"
+spec:
+  helm:
+    chartSpec:
+      chart: marimo
+      version: "0.3.0"
+      interval: 10m
+      sourceRef:
+        # The HelmRepository must live in the same namespace as this
+        # ServiceTemplate (kcm-system); k0rdent's schema has no sourceRef.namespace.
+        # In prod it points at oci://ghcr.io/exalsius/exalsius-workspace-hub/charts;
+        # locally the harness creates a same-named one at the kind registry.
+        kind: HelmRepository
+        name: exalsius-workspace-hub

--- a/manifests/marimo/0.3.0/workspaceclass.yaml
+++ b/manifests/marimo/0.3.0/workspaceclass.yaml
@@ -1,0 +1,46 @@
+# Workspace catalog entry (management-cluster CR).
+#
+# TEMPLATE — rendered at release time into
+#   manifests/marimo/0.3.0/workspaceclass.yaml
+# Placeholders 0.3.0 / 0-3-0 are substituted from Chart.yaml.
+#
+# The class is version-named and immutable; a WorkspaceDeployment pins it
+# exactly, so a running workspace's definition never changes underneath it.
+# gpuType / gpuNodeSelector are intentionally NOT set here — they are
+# per-deployment, cluster-dependent choices (the operator rejects them on a
+# class). The default is CPU-only (gpuCount 0); a deployment opts into a GPU.
+apiVersion: workspaces.exalsius.ai/v1
+kind: WorkspaceClass
+metadata:
+  name: marimo-0-3-0
+  labels:
+    workspaces.exalsius.ai/template: marimo
+    workspaces.exalsius.ai/version: "0.3.0"
+spec:
+  displayName: "Marimo Notebook"
+  description: >-
+    Single-user Marimo reactive notebook. One framework-free image runs on CPU,
+    NVIDIA, or AMD ROCm nodes; install PyTorch (cuda/rocm) inside the notebook as
+    needed.
+  serviceTemplate:
+    name: marimo-0-3-0
+    namespace: kcm-system
+  defaultResources:
+    replicas: 1
+    perReplica:
+      cpu: "4"
+      memory: "8Gi"
+      storage: "20Gi"
+      gpuCount: 0
+  accessEndpoints:
+    - name: http
+      protocol: HTTP
+      port: 80
+      description: "Marimo notebook web UI"
+  userFacingConfig:
+    - helmValuePath: tokenPassword
+      displayName: "Notebook Password"
+      description: "Password to access the Marimo web UI"
+      type: secret
+      required: true
+  deployTimeout: 15m


### PR DESCRIPTION
Automated render of version-pinned workspace manifests following a chart publish.

This PR is generated by the `Build and push helm charts` workflow.
Review and merge it to publish the rendered manifests to main.